### PR TITLE
non-global Rollbar clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ import (
 )
 
 func main() {
-  rollbar.Token = "MY_TOKEN"
-  rollbar.Environment = "production"                 // defaults to "development"
-  rollbar.CodeVersion = "v2"                         // optional Git hash/branch/tag (required for GitHub integration)
-  rollbar.ServerHost = "web.1"                       // optional override; defaults to hostname
-  rollbar.ServerRoot = "github.com/heroku/myproject" // path of project (required for GitHub integration and non-project stacktrace collapsing)
+  rollbar.SetToken("MY_TOKEN")
+  rollbar.SetEnvironment("production")                 // defaults to "development"
+  rollbar.SetCodeVersion("v2")                         // optional Git hash/branch/tag (required for GitHub integration)
+  rollbar.SetServerHost("web.1")                       // optional override; defaults to hostname
+  rollbar.SetServerRoot("github.com/heroku/myproject") // path of project (required for GitHub integration and non-project stacktrace collapsing)
 
   result, err := DoSomething()
   if err != nil {
@@ -59,3 +59,4 @@ A big thank you to everyone who has contributed pull requests and bug reports:
 * @kjk
 * @Soulou
 * @paulmach
+* @fabiokung

--- a/client.go
+++ b/client.go
@@ -12,6 +12,18 @@ import (
 )
 
 type Client interface {
+	// Rollbar access token.
+	SetToken(token string)
+	// All errors and messages will be submitted under this environment.
+	SetEnvironment(environment string)
+	// String describing the running code version on the server
+	SetCodeVersion(codeVersion string)
+	// host: The server hostname. Will be indexed.
+	SetServerHost(serverHost string)
+	// root: Path to the application code root, not including the final slash.
+	// Used to collapse non-project code when displaying tracebacks.
+	SetServerRoot(serverRoot string)
+
 	Error(level string, err error)
 	ErrorWithExtras(level string, err error, extras map[string]interface{})
 	ErrorWithStackSkip(level string, err error, skip int)
@@ -58,10 +70,6 @@ type Rollbar struct {
 
 // New returns the default implementation of a Client
 func New(token, environment, codeVersion, serverHost, serverRoot string) Client {
-	return newRollbar(token, environment, codeVersion, serverHost, serverRoot)
-}
-
-func newRollbar(token, environment, codeVersion, serverHost, serverRoot string) *Rollbar {
 	buffer := 1000
 	client := &Rollbar{
 		Token:         token,
@@ -83,6 +91,26 @@ func newRollbar(token, environment, codeVersion, serverHost, serverRoot string) 
 		}
 	}()
 	return client
+}
+
+func (c *Rollbar) SetToken(token string) {
+	c.Token = token
+}
+
+func (c *Rollbar) SetEnvironment(environment string) {
+	c.Environment = environment
+}
+
+func (c *Rollbar) SetCodeVersion(codeVersion string) {
+	c.CodeVersion = codeVersion
+}
+
+func (c *Rollbar) SetServerHost(serverHost string) {
+	c.ServerHost = serverHost
+}
+
+func (c *Rollbar) SetServerRoot(serverRoot string) {
+	c.ServerRoot = serverRoot
 }
 
 // -- Error reporting

--- a/client.go
+++ b/client.go
@@ -138,7 +138,6 @@ func (c *AsyncClient) SetServerRoot(serverRoot string) {
 
 var noExtras map[string]interface{}
 
-// Error asynchronously sends an error to Rollbar with the given severity level.
 func (c *AsyncClient) Error(level string, err error) {
 	c.ErrorWithExtras(level, err, noExtras)
 }

--- a/client.go
+++ b/client.go
@@ -1,0 +1,290 @@
+package rollbar
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"regexp"
+	"runtime"
+	"sync"
+	"time"
+)
+
+type Client interface {
+	Error(level string, err error)
+	ErrorWithExtras(level string, err error, extras map[string]interface{})
+	ErrorWithStackSkip(level string, err error, skip int)
+	ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{})
+
+	RequestError(level string, r *http.Request, err error)
+	RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{})
+	RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int)
+	RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{})
+
+	Message(level string, msg string)
+	MessageWithExtras(level string, msg string, extras map[string]interface{})
+
+	Wait()
+}
+
+// Rollbar is the default concrete implementation of the Client interface
+type Rollbar struct {
+	// Rollbar access token. If this is blank, no errors will be reported to
+	// Rollbar.
+	Token string
+	// All errors and messages will be submitted under this environment.
+	Environment string
+	// API endpoint for Rollbar.
+	Endpoint string
+	// Maximum number of errors allowed in the sending queue before we start
+	// dropping new errors on the floor.
+	Buffer int
+	// Filter HTTP Headers parameters from being sent to Rollbar.
+	FilterHeaders *regexp.Regexp
+	// Filter GET and POST parameters from being sent to Rollbar.
+	FilterFields *regexp.Regexp
+	// String describing the running code version on the server
+	CodeVersion string
+	// host: The server hostname. Will be indexed.
+	ServerHost string
+	// root: Path to the application code root, not including the final slash.
+	// Used to collapse non-project code when displaying tracebacks.
+	ServerRoot string
+	// Queue of messages to be sent.
+	bodyChannel chan map[string]interface{}
+	waitGroup   sync.WaitGroup
+}
+
+// New returns the default implementation of a Client
+func New(token, environment, codeVersion, serverHost, serverRoot string) Client {
+	return newRollbar(token, environment, codeVersion, serverHost, serverRoot)
+}
+
+func newRollbar(token, environment, codeVersion, serverHost, serverRoot string) *Rollbar {
+	buffer := 1000
+	client := &Rollbar{
+		Token:         token,
+		Environment:   environment,
+		Endpoint:      "https://api.rollbar.com/api/1/item/",
+		Buffer:        1000,
+		FilterHeaders: regexp.MustCompile("Authorization"),
+		FilterFields:  regexp.MustCompile("password|secret|token"),
+		CodeVersion:   codeVersion,
+		ServerHost:    serverHost,
+		ServerRoot:    serverRoot,
+		bodyChannel:   make(chan map[string]interface{}, buffer),
+	}
+
+	go func() {
+		for body := range client.bodyChannel {
+			client.post(body)
+			client.waitGroup.Done()
+		}
+	}()
+	return client
+}
+
+// -- Error reporting
+
+var noExtras map[string]interface{}
+
+// Error asynchronously sends an error to Rollbar with the given severity level.
+func (c *Rollbar) Error(level string, err error) {
+	c.ErrorWithExtras(level, err, noExtras)
+}
+
+// ErrorWithExtras asynchronously sends an error to Rollbar with the given severity level with extra custom data.
+func (c *Rollbar) ErrorWithExtras(level string, err error, extras map[string]interface{}) {
+	c.ErrorWithStackSkipWithExtras(level, err, 1, extras)
+}
+
+// RequestError asynchronously sends an error to Rollbar with the given
+// severity level and request-specific information.
+func (c *Rollbar) RequestError(level string, r *http.Request, err error) {
+	c.RequestErrorWithExtras(level, r, err, noExtras)
+}
+
+// RequestErrorWithExtras asynchronously sends an error to Rollbar with the given
+// severity level and request-specific information with extra custom data.
+func (c *Rollbar) RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
+}
+
+// ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
+// severity level and a given number of stack trace frames skipped.
+func (c *Rollbar) ErrorWithStackSkip(level string, err error, skip int) {
+	c.ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
+}
+
+// ErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar with the given
+// severity level and a given number of stack trace frames skipped with extra custom data.
+func (c *Rollbar) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	c.push(body)
+}
+
+// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
+// given severity level and a given number of stack trace frames skipped, in
+// addition to extra request-specific information.
+func (c *Rollbar) RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
+	c.RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
+}
+
+// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
+// given severity level and a given number of stack trace frames skipped, in
+// addition to extra request-specific information and extra custom data.
+func (c *Rollbar) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
+	body := c.buildBody(level, err.Error(), extras)
+	data := body["data"].(map[string]interface{})
+
+	errBody, fingerprint := errorBody(err, skip)
+	data["body"] = errBody
+	data["fingerprint"] = fingerprint
+
+	data["request"] = c.errorRequest(r)
+
+	c.push(body)
+}
+
+// -- Message reporting
+
+// Message asynchronously sends a message to Rollbar with the given severity
+// level. Rollbar request is asynchronous.
+func (c *Rollbar) Message(level string, msg string) {
+	c.MessageWithExtras(level, msg, noExtras)
+}
+
+// Message asynchronously sends a message to Rollbar with the given severity
+// level with extra custom data. Rollbar request is asynchronous.
+func (c *Rollbar) MessageWithExtras(level string, msg string, extras map[string]interface{}) {
+	body := c.buildBody(level, msg, extras)
+	data := body["data"].(map[string]interface{})
+	data["body"] = messageBody(msg)
+
+	c.push(body)
+}
+
+// -- Misc.
+
+// Wait will block until the queue of errors / messages is empty.
+func (c *Rollbar) Wait() {
+	c.waitGroup.Wait()
+}
+
+// Build the main JSON structure that will be sent to Rollbar with the
+// appropriate metadata.
+func (c *Rollbar) buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
+	timestamp := time.Now().Unix()
+	data := map[string]interface{}{
+		"environment":  c.Environment,
+		"title":        title,
+		"level":        level,
+		"timestamp":    timestamp,
+		"platform":     runtime.GOOS,
+		"language":     "go",
+		"code_version": c.CodeVersion,
+		"server": map[string]interface{}{
+			"host": c.ServerHost,
+			"root": c.ServerRoot,
+		},
+		"notifier": map[string]interface{}{
+			"name":    NAME,
+			"version": VERSION,
+		},
+	}
+
+	for k, v := range extras {
+		data[k] = v
+	}
+
+	return map[string]interface{}{
+		"access_token": c.Token,
+		"data":         data,
+	}
+}
+
+// Extract error details from a Request to a format that Rollbar accepts.
+func (c *Rollbar) errorRequest(r *http.Request) map[string]interface{} {
+	cleanQuery := filterParams(c.FilterFields, r.URL.Query())
+
+	return map[string]interface{}{
+		"url":     r.URL.String(),
+		"method":  r.Method,
+		"headers": flattenValues(filterParams(c.FilterHeaders, r.Header)),
+
+		// GET params
+		"query_string": url.Values(cleanQuery).Encode(),
+		"GET":          flattenValues(cleanQuery),
+
+		// POST / PUT params
+		"POST": flattenValues(filterParams(c.FilterFields, r.Form)),
+	}
+}
+
+// filterParams filters sensitive information like passwords from being sent to
+// Rollbar.
+func filterParams(pattern *regexp.Regexp, values map[string][]string) map[string][]string {
+	for key, _ := range values {
+		if pattern.Match([]byte(key)) {
+			values[key] = []string{FILTERED}
+		}
+	}
+
+	return values
+}
+
+func flattenValues(values map[string][]string) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	for k, v := range values {
+		if len(v) == 1 {
+			result[k] = v[0]
+		} else {
+			result[k] = v
+		}
+	}
+
+	return result
+}
+
+// -- POST handling
+
+// Queue the given JSON body to be POSTed to Rollbar.
+func (c *Rollbar) push(body map[string]interface{}) {
+	if len(c.bodyChannel) < c.Buffer {
+		c.waitGroup.Add(1)
+		c.bodyChannel <- body
+	} else {
+		rollbarError("buffer full, dropping error on the floor")
+	}
+}
+
+// POST the given JSON body to Rollbar synchronously.
+func (c *Rollbar) post(body map[string]interface{}) {
+	if len(c.Token) == 0 {
+		rollbarError("empty token")
+		return
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		rollbarError("failed to encode payload: %s", err.Error())
+		return
+	}
+
+	resp, err := http.Post(c.Endpoint, "application/json", bytes.NewReader(jsonBody))
+	if err != nil {
+		rollbarError("POST failed: %s", err.Error())
+	} else if resp.StatusCode != 200 {
+		rollbarError("received response: %s", resp.Status)
+	}
+	if resp != nil {
+		resp.Body.Close()
+	}
+}

--- a/client.go
+++ b/client.go
@@ -24,19 +24,45 @@ type Client interface {
 	// Used to collapse non-project code when displaying tracebacks.
 	SetServerRoot(serverRoot string)
 
+	// Error asynchronously sends an error to Rollbar with the given severity level.
 	Error(level string, err error)
+	// ErrorWithExtras asynchronously sends an error to Rollbar with the
+	// given severity level with extra custom data.
 	ErrorWithExtras(level string, err error, extras map[string]interface{})
+	// ErrorWithStackSkip asynchronously sends an error to Rollbar with the
+	// given severity level and a given number of stack trace frames skipped.
 	ErrorWithStackSkip(level string, err error, skip int)
+	// ErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar
+	// with the given severity level and a given number of stack trace
+	// frames skipped with extra custom data.
 	ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{})
 
+	// RequestError asynchronously sends an error to Rollbar with the given
+	// severity level and request-specific information.
 	RequestError(level string, r *http.Request, err error)
+	// RequestErrorWithExtras asynchronously sends an error to Rollbar with
+	// the given severity level and request-specific information with extra
+	// custom data.
 	RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{})
+	// RequestErrorWithStackSkip asynchronously sends an error to Rollbar
+	// with the given severity level and a given number of stack trace
+	// frames skipped, in addition to extra request-specific information.
 	RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int)
+	// RequestErrorWithStackSkipWithExtras asynchronously sends an error to
+	// Rollbar with the given severity level and a given number of stack
+	// trace frames skipped, in addition to extra request-specific
+	// information and extra custom data.
 	RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{})
 
+	// Message asynchronously sends a message to Rollbar with the given
+	// severity level. Rollbar request is asynchronous.
 	Message(level string, msg string)
+	// MessageWithExtras asynchronously sends a message to Rollbar with the
+	// given severity level with extra custom data. Rollbar request is
+	// asynchronous.
 	MessageWithExtras(level string, msg string, extras map[string]interface{})
 
+	// Wait will block until the queue of errors / messages is empty.
 	Wait()
 }
 
@@ -117,36 +143,26 @@ func (c *Rollbar) SetServerRoot(serverRoot string) {
 
 var noExtras map[string]interface{}
 
-// Error asynchronously sends an error to Rollbar with the given severity level.
 func (c *Rollbar) Error(level string, err error) {
 	c.ErrorWithExtras(level, err, noExtras)
 }
 
-// ErrorWithExtras asynchronously sends an error to Rollbar with the given severity level with extra custom data.
 func (c *Rollbar) ErrorWithExtras(level string, err error, extras map[string]interface{}) {
 	c.ErrorWithStackSkipWithExtras(level, err, 1, extras)
 }
 
-// RequestError asynchronously sends an error to Rollbar with the given
-// severity level and request-specific information.
 func (c *Rollbar) RequestError(level string, r *http.Request, err error) {
 	c.RequestErrorWithExtras(level, r, err, noExtras)
 }
 
-// RequestErrorWithExtras asynchronously sends an error to Rollbar with the given
-// severity level and request-specific information with extra custom data.
 func (c *Rollbar) RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
 	c.RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
 }
 
-// ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
-// severity level and a given number of stack trace frames skipped.
 func (c *Rollbar) ErrorWithStackSkip(level string, err error, skip int) {
 	c.ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
 }
 
-// ErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar with the given
-// severity level and a given number of stack trace frames skipped with extra custom data.
 func (c *Rollbar) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
 	data := body["data"].(map[string]interface{})
@@ -157,16 +173,10 @@ func (c *Rollbar) ErrorWithStackSkipWithExtras(level string, err error, skip int
 	c.push(body)
 }
 
-// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
-// given severity level and a given number of stack trace frames skipped, in
-// addition to extra request-specific information.
 func (c *Rollbar) RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
 	c.RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
 }
 
-// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
-// given severity level and a given number of stack trace frames skipped, in
-// addition to extra request-specific information and extra custom data.
 func (c *Rollbar) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	body := c.buildBody(level, err.Error(), extras)
 	data := body["data"].(map[string]interface{})
@@ -182,14 +192,10 @@ func (c *Rollbar) RequestErrorWithStackSkipWithExtras(level string, r *http.Requ
 
 // -- Message reporting
 
-// Message asynchronously sends a message to Rollbar with the given severity
-// level. Rollbar request is asynchronous.
 func (c *Rollbar) Message(level string, msg string) {
 	c.MessageWithExtras(level, msg, noExtras)
 }
 
-// Message asynchronously sends a message to Rollbar with the given severity
-// level with extra custom data. Rollbar request is asynchronous.
 func (c *Rollbar) MessageWithExtras(level string, msg string, extras map[string]interface{}) {
 	body := c.buildBody(level, msg, extras)
 	data := body["data"].(map[string]interface{})
@@ -200,7 +206,6 @@ func (c *Rollbar) MessageWithExtras(level string, msg string, extras map[string]
 
 // -- Misc.
 
-// Wait will block until the queue of errors / messages is empty.
 func (c *Rollbar) Wait() {
 	c.waitGroup.Wait()
 }

--- a/rollbar.go
+++ b/rollbar.go
@@ -29,22 +29,28 @@ var (
 	Std         = New("", "development", "", hostname, "")
 )
 
+// Rollbar access token.
 func SetToken(token string) {
 	Std.SetToken(token)
 }
 
+// All errors and messages will be submitted under this environment.
 func SetEnvironment(environment string) {
 	Std.SetEnvironment(environment)
 }
 
+// String describing the running code version on the server
 func SetCodeVersion(codeVersion string) {
 	Std.SetCodeVersion(codeVersion)
 }
 
+// host: The server hostname. Will be indexed.
 func SetServerHost(serverHost string) {
 	Std.SetServerHost(serverHost)
 }
 
+// root: Path to the application code root, not including the final slash.
+// Used to collapse non-project code when displaying tracebacks.
 func SetServerRoot(serverRoot string) {
 	Std.SetServerRoot(serverRoot)
 }
@@ -56,7 +62,8 @@ func Error(level string, err error) {
 	Std.Error(level, err)
 }
 
-// Error asynchronously sends an error to Rollbar with the given severity level with extra custom data.
+// ErrorWithExtras asynchronously sends an error to Rollbar with the given
+// severity level with extra custom data.
 func ErrorWithExtras(level string, err error, extras map[string]interface{}) {
 	Std.ErrorWithExtras(level, err, extras)
 }
@@ -67,7 +74,7 @@ func RequestError(level string, r *http.Request, err error) {
 	Std.RequestError(level, r, err)
 }
 
-// RequestError asynchronously sends an error to Rollbar with the given
+// RequestErrorWithExtras asynchronously sends an error to Rollbar with the given
 // severity level and request-specific information with extra custom data.
 func RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
 	Std.RequestErrorWithExtras(level, r, err, extras)
@@ -79,7 +86,7 @@ func ErrorWithStackSkip(level string, err error, skip int) {
 	Std.ErrorWithStackSkip(level, err, skip)
 }
 
-// ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
+// ErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar with the given
 // severity level and a given number of stack trace frames skipped with extra custom data.
 func ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
 	Std.ErrorWithStackSkipWithExtras(level, err, skip, extras)
@@ -92,9 +99,9 @@ func RequestErrorWithStackSkip(level string, r *http.Request, err error, skip in
 	Std.RequestErrorWithStackSkip(level, r, err, skip)
 }
 
-// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
-// given severity level and a given number of stack trace frames skipped, in
-// addition to extra request-specific information and extra custom data.
+// RequestErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar
+// with the given severity level and a given number of stack trace frames skipped,
+// in addition to extra request-specific information and extra custom data.
 func RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	Std.RequestErrorWithStackSkipWithExtras(level, r, err, skip, extras)
 }
@@ -107,7 +114,7 @@ func Message(level string, msg string) {
 	Std.Message(level, msg)
 }
 
-// Message asynchronously sends a message to Rollbar with the given severity
+// MessageWithExtras asynchronously sends a message to Rollbar with the given severity
 // level with extra custom data. Rollbar request is asynchronous.
 func MessageWithExtras(level string, msg string, extras map[string]interface{}) {
 	Std.MessageWithExtras(level, msg, extras)

--- a/rollbar.go
+++ b/rollbar.go
@@ -26,84 +26,84 @@ const (
 
 var (
 	hostname, _ = os.Hostname()
-	Std         = New("", "development", "", hostname, "")
+	std         = New("", "development", "", hostname, "")
 )
 
 // Rollbar access token.
 func SetToken(token string) {
-	Std.SetToken(token)
+	std.SetToken(token)
 }
 
 // All errors and messages will be submitted under this environment.
 func SetEnvironment(environment string) {
-	Std.SetEnvironment(environment)
+	std.SetEnvironment(environment)
 }
 
 // String describing the running code version on the server
 func SetCodeVersion(codeVersion string) {
-	Std.SetCodeVersion(codeVersion)
+	std.SetCodeVersion(codeVersion)
 }
 
 // host: The server hostname. Will be indexed.
 func SetServerHost(serverHost string) {
-	Std.SetServerHost(serverHost)
+	std.SetServerHost(serverHost)
 }
 
 // root: Path to the application code root, not including the final slash.
 // Used to collapse non-project code when displaying tracebacks.
 func SetServerRoot(serverRoot string) {
-	Std.SetServerRoot(serverRoot)
+	std.SetServerRoot(serverRoot)
 }
 
 // -- Error reporting
 
 // Error asynchronously sends an error to Rollbar with the given severity level.
 func Error(level string, err error) {
-	Std.Error(level, err)
+	std.Error(level, err)
 }
 
 // ErrorWithExtras asynchronously sends an error to Rollbar with the given
 // severity level with extra custom data.
 func ErrorWithExtras(level string, err error, extras map[string]interface{}) {
-	Std.ErrorWithExtras(level, err, extras)
+	std.ErrorWithExtras(level, err, extras)
 }
 
 // RequestError asynchronously sends an error to Rollbar with the given
 // severity level and request-specific information.
 func RequestError(level string, r *http.Request, err error) {
-	Std.RequestError(level, r, err)
+	std.RequestError(level, r, err)
 }
 
 // RequestErrorWithExtras asynchronously sends an error to Rollbar with the given
 // severity level and request-specific information with extra custom data.
 func RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
-	Std.RequestErrorWithExtras(level, r, err, extras)
+	std.RequestErrorWithExtras(level, r, err, extras)
 }
 
 // ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
 // severity level and a given number of stack trace frames skipped.
 func ErrorWithStackSkip(level string, err error, skip int) {
-	Std.ErrorWithStackSkip(level, err, skip)
+	std.ErrorWithStackSkip(level, err, skip)
 }
 
 // ErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar with the given
 // severity level and a given number of stack trace frames skipped with extra custom data.
 func ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
-	Std.ErrorWithStackSkipWithExtras(level, err, skip, extras)
+	std.ErrorWithStackSkipWithExtras(level, err, skip, extras)
 }
 
 // RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
 // given severity level and a given number of stack trace frames skipped, in
 // addition to extra request-specific information.
 func RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
-	Std.RequestErrorWithStackSkip(level, r, err, skip)
+	std.RequestErrorWithStackSkip(level, r, err, skip)
 }
 
 // RequestErrorWithStackSkipWithExtras asynchronously sends an error to Rollbar
 // with the given severity level and a given number of stack trace frames skipped,
 // in addition to extra request-specific information and extra custom data.
 func RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
-	Std.RequestErrorWithStackSkipWithExtras(level, r, err, skip, extras)
+	std.RequestErrorWithStackSkipWithExtras(level, r, err, skip, extras)
 }
 
 // -- Message reporting
@@ -111,20 +111,20 @@ func RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err erro
 // Message asynchronously sends a message to Rollbar with the given severity
 // level. Rollbar request is asynchronous.
 func Message(level string, msg string) {
-	Std.Message(level, msg)
+	std.Message(level, msg)
 }
 
 // MessageWithExtras asynchronously sends a message to Rollbar with the given severity
 // level with extra custom data. Rollbar request is asynchronous.
 func MessageWithExtras(level string, msg string, extras map[string]interface{}) {
-	Std.MessageWithExtras(level, msg, extras)
+	std.MessageWithExtras(level, msg, extras)
 }
 
 // -- Misc.
 
 // Wait will block until the queue of errors / messages is empty.
 func Wait() {
-	Std.Wait()
+	std.Wait()
 }
 
 // Errors can implement this interface to create a trace_chain

--- a/rollbar.go
+++ b/rollbar.go
@@ -1,20 +1,13 @@
 package rollbar
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
 	"hash/adler32"
 	"log"
 	"net/http"
-	"net/url"
 	"os"
 	"reflect"
-	"regexp"
-	"runtime"
 	"strings"
-	"sync"
-	"time"
 )
 
 const (
@@ -30,78 +23,6 @@ const (
 
 	FILTERED = "[FILTERED]"
 )
-
-type Rollbar struct {
-	// Rollbar access token. If this is blank, no errors will be reported to
-	// Rollbar.
-	Token string
-	// All errors and messages will be submitted under this environment.
-	Environment string
-	// API endpoint for Rollbar.
-	Endpoint string
-	// Maximum number of errors allowed in the sending queue before we start
-	// dropping new errors on the floor.
-	Buffer int
-	// Filter HTTP Headers parameters from being sent to Rollbar.
-	FilterHeaders *regexp.Regexp
-	// Filter GET and POST parameters from being sent to Rollbar.
-	FilterFields *regexp.Regexp
-	// String describing the running code version on the server
-	CodeVersion string
-	// host: The server hostname. Will be indexed.
-	ServerHost string
-	// root: Path to the application code root, not including the final slash.
-	// Used to collapse non-project code when displaying tracebacks.
-	ServerRoot string
-	// Queue of messages to be sent.
-	bodyChannel chan map[string]interface{}
-	waitGroup   sync.WaitGroup
-}
-
-type Client interface {
-	Error(level string, err error)
-	ErrorWithExtras(level string, err error, extras map[string]interface{})
-	ErrorWithStackSkip(level string, err error, skip int)
-	ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{})
-
-	RequestError(level string, r *http.Request, err error)
-	RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{})
-	RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int)
-	RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{})
-
-	Message(level string, msg string)
-	MessageWithExtras(level string, msg string, extras map[string]interface{})
-
-	Wait()
-}
-
-func New(token, environment, codeVersion, serverHost, serverRoot string) Client {
-	return newRollbar(token, environment, codeVersion, serverHost, serverRoot)
-}
-
-func newRollbar(token, environment, codeVersion, serverHost, serverRoot string) *Rollbar {
-	buffer := 1000
-	client := &Rollbar{
-		Token:         token,
-		Environment:   environment,
-		Endpoint:      "https://api.rollbar.com/api/1/item/",
-		Buffer:        1000,
-		FilterHeaders: regexp.MustCompile("Authorization"),
-		FilterFields:  regexp.MustCompile("password|secret|token"),
-		CodeVersion:   codeVersion,
-		ServerHost:    serverHost,
-		ServerRoot:    serverRoot,
-		bodyChannel:   make(chan map[string]interface{}, buffer),
-	}
-
-	go func() {
-		for body := range client.bodyChannel {
-			client.post(body)
-			client.waitGroup.Done()
-		}
-	}()
-	return client
-}
 
 var (
 	hostname, _ = os.Hostname()
@@ -130,26 +51,14 @@ func SetServerRoot(serverRoot string) {
 
 // -- Error reporting
 
-var noExtras map[string]interface{}
-
 // Error asynchronously sends an error to Rollbar with the given severity level.
 func Error(level string, err error) {
 	Std.Error(level, err)
 }
 
-// Error asynchronously sends an error to Rollbar with the given severity level.
-func (c *Rollbar) Error(level string, err error) {
-	c.ErrorWithExtras(level, err, noExtras)
-}
-
 // Error asynchronously sends an error to Rollbar with the given severity level with extra custom data.
 func ErrorWithExtras(level string, err error, extras map[string]interface{}) {
 	Std.ErrorWithExtras(level, err, extras)
-}
-
-// Error asynchronously sends an error to Rollbar with the given severity level with extra custom data.
-func (c *Rollbar) ErrorWithExtras(level string, err error, extras map[string]interface{}) {
-	c.ErrorWithStackSkipWithExtras(level, err, 1, extras)
 }
 
 // RequestError asynchronously sends an error to Rollbar with the given
@@ -159,21 +68,9 @@ func RequestError(level string, r *http.Request, err error) {
 }
 
 // RequestError asynchronously sends an error to Rollbar with the given
-// severity level and request-specific information.
-func (c *Rollbar) RequestError(level string, r *http.Request, err error) {
-	c.RequestErrorWithExtras(level, r, err, noExtras)
-}
-
-// RequestError asynchronously sends an error to Rollbar with the given
 // severity level and request-specific information with extra custom data.
 func RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
 	Std.RequestErrorWithExtras(level, r, err, extras)
-}
-
-// RequestError asynchronously sends an error to Rollbar with the given
-// severity level and request-specific information with extra custom data.
-func (c *Rollbar) RequestErrorWithExtras(level string, r *http.Request, err error, extras map[string]interface{}) {
-	c.RequestErrorWithStackSkipWithExtras(level, r, err, 1, extras)
 }
 
 // ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
@@ -183,27 +80,9 @@ func ErrorWithStackSkip(level string, err error, skip int) {
 }
 
 // ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
-// severity level and a given number of stack trace frames skipped.
-func (c *Rollbar) ErrorWithStackSkip(level string, err error, skip int) {
-	c.ErrorWithStackSkipWithExtras(level, err, skip, noExtras)
-}
-
-// ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
 // severity level and a given number of stack trace frames skipped with extra custom data.
 func ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
 	Std.ErrorWithStackSkipWithExtras(level, err, skip, extras)
-}
-
-// ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
-// severity level and a given number of stack trace frames skipped with extra custom data.
-func (c *Rollbar) ErrorWithStackSkipWithExtras(level string, err error, skip int, extras map[string]interface{}) {
-	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
-	c.push(body)
 }
 
 // RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
@@ -215,32 +94,9 @@ func RequestErrorWithStackSkip(level string, r *http.Request, err error, skip in
 
 // RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
 // given severity level and a given number of stack trace frames skipped, in
-// addition to extra request-specific information.
-func (c *Rollbar) RequestErrorWithStackSkip(level string, r *http.Request, err error, skip int) {
-	c.RequestErrorWithStackSkipWithExtras(level, r, err, skip, noExtras)
-}
-
-// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
-// given severity level and a given number of stack trace frames skipped, in
 // addition to extra request-specific information and extra custom data.
 func RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
 	Std.RequestErrorWithStackSkipWithExtras(level, r, err, skip, extras)
-}
-
-// RequestErrorWithStackSkip asynchronously sends an error to Rollbar with the
-// given severity level and a given number of stack trace frames skipped, in
-// addition to extra request-specific information and extra custom data.
-func (c *Rollbar) RequestErrorWithStackSkipWithExtras(level string, r *http.Request, err error, skip int, extras map[string]interface{}) {
-	body := c.buildBody(level, err.Error(), extras)
-	data := body["data"].(map[string]interface{})
-
-	errBody, fingerprint := errorBody(err, skip)
-	data["body"] = errBody
-	data["fingerprint"] = fingerprint
-
-	data["request"] = c.errorRequest(r)
-
-	c.push(body)
 }
 
 // -- Message reporting
@@ -252,25 +108,9 @@ func Message(level string, msg string) {
 }
 
 // Message asynchronously sends a message to Rollbar with the given severity
-// level. Rollbar request is asynchronous.
-func (c *Rollbar) Message(level string, msg string) {
-	c.MessageWithExtras(level, msg, noExtras)
-}
-
-// Message asynchronously sends a message to Rollbar with the given severity
 // level with extra custom data. Rollbar request is asynchronous.
 func MessageWithExtras(level string, msg string, extras map[string]interface{}) {
 	Std.MessageWithExtras(level, msg, extras)
-}
-
-// Message asynchronously sends a message to Rollbar with the given severity
-// level with extra custom data. Rollbar request is asynchronous.
-func (c *Rollbar) MessageWithExtras(level string, msg string, extras map[string]interface{}) {
-	body := c.buildBody(level, msg, extras)
-	data := body["data"].(map[string]interface{})
-	data["body"] = messageBody(msg)
-
-	c.push(body)
 }
 
 // -- Misc.
@@ -278,43 +118,6 @@ func (c *Rollbar) MessageWithExtras(level string, msg string, extras map[string]
 // Wait will block until the queue of errors / messages is empty.
 func Wait() {
 	Std.Wait()
-}
-
-// Wait will block until the queue of errors / messages is empty.
-func (c *Rollbar) Wait() {
-	c.waitGroup.Wait()
-}
-
-// Build the main JSON structure that will be sent to Rollbar with the
-// appropriate metadata.
-func (c *Rollbar) buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
-	timestamp := time.Now().Unix()
-	data := map[string]interface{}{
-		"environment":  c.Environment,
-		"title":        title,
-		"level":        level,
-		"timestamp":    timestamp,
-		"platform":     runtime.GOOS,
-		"language":     "go",
-		"code_version": c.CodeVersion,
-		"server": map[string]interface{}{
-			"host": c.ServerHost,
-			"root": c.ServerRoot,
-		},
-		"notifier": map[string]interface{}{
-			"name":    NAME,
-			"version": VERSION,
-		},
-	}
-
-	for k, v := range extras {
-		data[k] = v
-	}
-
-	return map[string]interface{}{
-		"access_token": c.Token,
-		"data":         data,
-	}
 }
 
 // Errors can implement this interface to create a trace_chain
@@ -379,50 +182,6 @@ func getOrBuildStack(err error, parent error, skip int) Stack {
 	return make(Stack, 0)
 }
 
-// Extract error details from a Request to a format that Rollbar accepts.
-func (c *Rollbar) errorRequest(r *http.Request) map[string]interface{} {
-	cleanQuery := filterParams(c.FilterFields, r.URL.Query())
-
-	return map[string]interface{}{
-		"url":     r.URL.String(),
-		"method":  r.Method,
-		"headers": flattenValues(filterParams(c.FilterHeaders, r.Header)),
-
-		// GET params
-		"query_string": url.Values(cleanQuery).Encode(),
-		"GET":          flattenValues(cleanQuery),
-
-		// POST / PUT params
-		"POST": flattenValues(filterParams(c.FilterFields, r.Form)),
-	}
-}
-
-// filterParams filters sensitive information like passwords from being sent to
-// Rollbar.
-func filterParams(pattern *regexp.Regexp, values map[string][]string) map[string][]string {
-	for key, _ := range values {
-		if pattern.Match([]byte(key)) {
-			values[key] = []string{FILTERED}
-		}
-	}
-
-	return values
-}
-
-func flattenValues(values map[string][]string) map[string]interface{} {
-	result := make(map[string]interface{})
-
-	for k, v := range values {
-		if len(v) == 1 {
-			result[k] = v[0]
-		} else {
-			result[k] = v
-		}
-	}
-
-	return result
-}
-
 // Build a message inner-body for the given message string.
 func messageBody(s string) map[string]interface{} {
 	return map[string]interface{}{
@@ -441,42 +200,6 @@ func errorClass(err error) string {
 		return fmt.Sprintf("{%x}", checksum)
 	} else {
 		return strings.TrimPrefix(class, "*")
-	}
-}
-
-// -- POST handling
-
-// Queue the given JSON body to be POSTed to Rollbar.
-func (c *Rollbar) push(body map[string]interface{}) {
-	if len(c.bodyChannel) < c.Buffer {
-		c.waitGroup.Add(1)
-		c.bodyChannel <- body
-	} else {
-		rollbarError("buffer full, dropping error on the floor")
-	}
-}
-
-// POST the given JSON body to Rollbar synchronously.
-func (c *Rollbar) post(body map[string]interface{}) {
-	if len(c.Token) == 0 {
-		rollbarError("empty token")
-		return
-	}
-
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		rollbarError("failed to encode payload: %s", err.Error())
-		return
-	}
-
-	resp, err := http.Post(c.Endpoint, "application/json", bytes.NewReader(jsonBody))
-	if err != nil {
-		rollbarError("POST failed: %s", err.Error())
-	} else if resp.StatusCode != 200 {
-		rollbarError("received response: %s", resp.Status)
-	}
-	if resp != nil {
-		resp.Body.Close()
 	}
 }
 

--- a/rollbar.go
+++ b/rollbar.go
@@ -26,27 +26,27 @@ const (
 
 var (
 	hostname, _ = os.Hostname()
-	Std         = newRollbar("", "development", "", hostname, "")
+	Std         = New("", "development", "", hostname, "")
 )
 
 func SetToken(token string) {
-	Std.Token = token
+	Std.SetToken(token)
 }
 
 func SetEnvironment(environment string) {
-	Std.Environment = environment
+	Std.SetEnvironment(environment)
 }
 
 func SetCodeVersion(codeVersion string) {
-	Std.CodeVersion = codeVersion
+	Std.SetCodeVersion(codeVersion)
 }
 
 func SetServerHost(serverHost string) {
-	Std.ServerHost = serverHost
+	Std.SetServerHost(serverHost)
 }
 
 func SetServerRoot(serverRoot string) {
-	Std.ServerRoot = serverRoot
+	Std.SetServerRoot(serverRoot)
 }
 
 // -- Error reporting

--- a/rollbar.go
+++ b/rollbar.go
@@ -122,11 +122,6 @@ func MessageWithExtras(level string, msg string, extras map[string]interface{}) 
 
 // -- Misc.
 
-// Wait will block until the queue of errors / messages is empty.
-func Wait() {
-	std.Wait()
-}
-
 // Errors can implement this interface to create a trace_chain
 // Callers are required to call BuildStack on their own at the
 // time the cause is wrapped.

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -46,8 +46,8 @@ func TestErrorClass(t *testing.T) {
 }
 
 func TestEverything(t *testing.T) {
-	Token = os.Getenv("TOKEN")
-	Environment = "test"
+	SetToken(os.Getenv("TOKEN"))
+	SetEnvironment("test")
 
 	Error("critical", errors.New("Normal critical error"))
 	Error("error", &CustomError{"This is a custom error"})
@@ -74,7 +74,7 @@ func TestErrorRequest(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
 	r.RemoteAddr = "1.1.1.1:123"
 
-	object := errorRequest(r)
+	object := Std.errorRequest(r)
 
 	if object["url"] != "http://foo.com/somethere?param1=true" {
 		t.Errorf("wrong url, got %v", object["url"])
@@ -96,7 +96,7 @@ func TestFilterParams(t *testing.T) {
 		"access_token": []string{"one"},
 	}
 
-	clean := filterParams(FilterFields, values)
+	clean := filterParams(Std.FilterFields, values)
 	if clean["password"][0] != FILTERED {
 		t.Error("should filter password parameter")
 	}

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -74,7 +74,7 @@ func TestErrorRequest(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
 	r.RemoteAddr = "1.1.1.1:123"
 
-	object := Std.errorRequest(r)
+	object := Std.(*Rollbar).errorRequest(r)
 
 	if object["url"] != "http://foo.com/somethere?param1=true" {
 		t.Errorf("wrong url, got %v", object["url"])
@@ -96,7 +96,7 @@ func TestFilterParams(t *testing.T) {
 		"access_token": []string{"one"},
 	}
 
-	clean := filterParams(Std.FilterFields, values)
+	clean := filterParams(Std.(*Rollbar).FilterFields, values)
 	if clean["password"][0] != FILTERED {
 		t.Error("should filter password parameter")
 	}

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -74,7 +74,7 @@ func TestErrorRequest(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
 	r.RemoteAddr = "1.1.1.1:123"
 
-	object := Std.(*Rollbar).errorRequest(r)
+	object := std.(*Rollbar).errorRequest(r)
 
 	if object["url"] != "http://foo.com/somethere?param1=true" {
 		t.Errorf("wrong url, got %v", object["url"])
@@ -96,7 +96,7 @@ func TestFilterParams(t *testing.T) {
 		"access_token": []string{"one"},
 	}
 
-	clean := filterParams(Std.(*Rollbar).FilterFields, values)
+	clean := filterParams(std.(*Rollbar).FilterFields, values)
 	if clean["password"][0] != FILTERED {
 		t.Error("should filter password parameter")
 	}

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -67,14 +67,14 @@ func TestEverything(t *testing.T) {
 
 	// If you don't see the message sent on line 65 in Rollbar, that means this
 	// is broken:
-	Wait()
+	std.(*AsyncClient).wait()
 }
 
 func TestErrorRequest(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
 	r.RemoteAddr = "1.1.1.1:123"
 
-	object := std.(*Rollbar).errorRequest(r)
+	object := std.(*AsyncClient).errorRequest(r)
 
 	if object["url"] != "http://foo.com/somethere?param1=true" {
 		t.Errorf("wrong url, got %v", object["url"])
@@ -96,7 +96,7 @@ func TestFilterParams(t *testing.T) {
 		"access_token": []string{"one"},
 	}
 
-	clean := filterParams(std.(*Rollbar).FilterFields, values)
+	clean := filterParams(std.(*AsyncClient).FilterFields, values)
 	if clean["password"][0] != FILTERED {
 		t.Error("should filter password parameter")
 	}


### PR DESCRIPTION
Also introduce the `Client` interface, so code using this library can be tested (i.e.: others can mock the rollbar client).

These changes are (mostly) backwards compatible. I kept the global functions (e.g.: `rollbar.Message(...)`), backed by a singleton global `Client` (`rollbar.std`), similarly to what the `log` package does with `log.Logger`.

@tysontate would you be interested in pulling this back upstream?
