### PR TITLE
bring Wait() back

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package rollbar
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -12,6 +13,8 @@ import (
 )
 
 type Client interface {
+	io.Closer
+
 	// Rollbar access token.
 	SetToken(token string)
 	// All errors and messages will be submitted under this environment.
@@ -209,6 +212,12 @@ func (c *AsyncClient) MessageWithExtras(level string, msg string, extras map[str
 // wait will block until the queue of errors / messages is empty.
 func (c *AsyncClient) Wait() {
 	c.waitGroup.Wait()
+}
+
+// Close on the asynchronous Client is an alias to Wait
+func (c *AsyncClient) Close() error {
+	c.Wait()
+	return nil
 }
 
 // Build the main JSON structure that will be sent to Rollbar with the

--- a/client.go
+++ b/client.go
@@ -91,6 +91,11 @@ type AsyncClient struct {
 
 // New returns the default implementation of a Client
 func New(token, environment, codeVersion, serverHost, serverRoot string) Client {
+	return NewAsync(token, environment, codeVersion, serverHost, serverRoot)
+}
+
+// NewAsync builds an asynchronous implementation of the Client interface
+func NewAsync(token, environment, codeVersion, serverHost, serverRoot string) *AsyncClient {
 	buffer := 1000
 	client := &AsyncClient{
 		Token:         token,
@@ -202,7 +207,7 @@ func (c *AsyncClient) MessageWithExtras(level string, msg string, extras map[str
 // -- Misc.
 
 // wait will block until the queue of errors / messages is empty.
-func (c *AsyncClient) wait() {
+func (c *AsyncClient) Wait() {
 	c.waitGroup.Wait()
 }
 

--- a/rollbar.go
+++ b/rollbar.go
@@ -26,7 +26,7 @@ const (
 
 var (
 	hostname, _ = os.Hostname()
-	std         = New("", "development", "", hostname, "")
+	std         = NewAsync("", "development", "", hostname, "")
 )
 
 // Rollbar access token.
@@ -118,6 +118,11 @@ func Message(level string, msg string) {
 // level with extra custom data. Rollbar request is asynchronous.
 func MessageWithExtras(level string, msg string, extras map[string]interface{}) {
 	std.MessageWithExtras(level, msg, extras)
+}
+
+// Wait will block until the queue of errors / messages is empty.
+func Wait() {
+	std.Wait()
 }
 
 // -- Misc.

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -67,14 +67,14 @@ func TestEverything(t *testing.T) {
 
 	// If you don't see the message sent on line 65 in Rollbar, that means this
 	// is broken:
-	std.(*AsyncClient).wait()
+	Wait()
 }
 
 func TestErrorRequest(t *testing.T) {
 	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
 	r.RemoteAddr = "1.1.1.1:123"
 
-	object := std.(*AsyncClient).errorRequest(r)
+	object := std.errorRequest(r)
 
 	if object["url"] != "http://foo.com/somethere?param1=true" {
 		t.Errorf("wrong url, got %v", object["url"])
@@ -96,7 +96,7 @@ func TestFilterParams(t *testing.T) {
 		"access_token": []string{"one"},
 	}
 
-	clean := filterParams(std.(*AsyncClient).FilterFields, values)
+	clean := filterParams(std.FilterFields, values)
 	if clean["password"][0] != FILTERED {
 		t.Error("should filter password parameter")
 	}


### PR DESCRIPTION
#1 broke compatibility with users that relied on the global client being async.

This PR adds it back where it makes sense: to the concrete `AsyncClient` implementation and to the global async client.

/cc @apg @ryanbrainard 
