### PR TITLE
Transfer ownership to Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ or allocated, we use the stack information from where the error was reported.
 Documentation
 =============
 
-[API docs on godoc.org](http://godoc.org/github.com/stvp/rollbar)
+[API docs on godoc.org](http://godoc.org/github.com/heroku/rollbar)
 
 Usage
 =====
@@ -54,7 +54,8 @@ And verify the reported errors manually.
 Contributors
 ============
 
-A big thank you to everyone who has contributed pull requests and bug reports:
+This library was originally written by @tysontate. A big thank you goes to
+everyone who has contributed pull requests and bug reports:
 
 * @kjk
 * @Soulou


### PR DESCRIPTION
I'm the person who wrote the upstream version of this library (stvp/rollbar).

This library has grown to support a lot of use cases and I don't want to maintain features that I don't personally use. Rather than merge your fork (which has some API changes) back upstream, would you be ok with me recommending this fork instead of mine? I created a separate library with a reduced feature set at [stvp/roll](https://github.com/stvp/roll) which is what I'm using internally now, and I'll leave the existing stvp/rollbar library up to avoid breaking anyone's build, but I'd point all new users to your library.

If you're ok with that, I'll also have Rollbar link to this repo as their recommended Go library.

Cheers,
Tyson
