### PR TITLE
Rollbar official notifier support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ background goroutine.
 Because Go's `error` type doesn't include stack information from when it was set
 or allocated, we use the stack information from where the error was reported.
 
+Official Libary
+================
+
+This library has been taken over by Rollbar as an officially supported SDK and can be found
+[here](https://github.com/rollbar/rollbar-go)
+
 Documentation
 =============
 


### PR DESCRIPTION
Hey I am the SDK engineer at Rollbar. We want to make Go one of our officially supported languages, and your library looks to me like the best place to start. I did a bare clone of your repo and pushed it up to https://github.com/rollbar/rollbar-go so that we don't end up with the official library as a fork of a fork, but we still want to maintain the git history.

We don't have any huge changes in mind at the moment, just some minor features to add, so this ideally won't be disruptive to your current use of the notifier. If there is some problem with this or another way you would prefer we proceed, please let me know.

I have looked through https://github.com/stvp/roll and https://github.com/stvp/rollbar as well, and think that your fork is the right starting point for how we see the notifier going forward.

I didn't see any other way to leave a comment on this repo besides opening a PR, so I created a simple documentation change that you can feel free to disregard for the time being.