### PR TITLE
Allow to specify a different logger

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -3,7 +3,6 @@ package rollbar
 import (
 	"fmt"
 	"hash/adler32"
-	"log"
 	"net/http"
 	"os"
 	"reflect"
@@ -58,6 +57,12 @@ func SetServerRoot(serverRoot string) {
 // custom: Any arbitrary metadata you want to send.
 func SetCustom(custom map[string]interface{}) {
 	std.SetCustom(custom)
+}
+
+// Logger to report Client problems when sending requests to Rollbar.
+// By default it is the standard log from the standard library.
+func SetClientLogger(logger ClientLogger) {
+	std.Logger = logger
 }
 
 // -- Getters
@@ -246,11 +251,4 @@ func errorClass(err error) string {
 	} else {
 		return strings.TrimPrefix(class, "*")
 	}
-}
-
-// -- rollbarError
-
-func rollbarError(format string, args ...interface{}) {
-	format = "Rollbar error: " + format + "\n"
-	log.Printf(format, args...)
 }

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -89,7 +89,7 @@ func TestBuildBody(t *testing.T) {
 		"EXTRA_CUSTOM_KEY":      "EXTRA_CUSTOM_VALUE",
 		"OVERRIDDEN_CUSTOM_KEY": "EXTRA",
 	}
-	body := std.(*AsyncClient).buildBody(ERR, "test error", extraCustom)
+	body := std.buildBody(ERR, "test error", extraCustom)
 
 	if body["data"] == nil {
 		t.Error("body should have data")
@@ -131,9 +131,9 @@ func TestErrorRequest(t *testing.T) {
 
 func TestFilterParams(t *testing.T) {
 	values := map[string][]string{
-		"password":     []string{"one"},
-		"ok":           []string{"one"},
-		"access_token": []string{"one"},
+		"password":     {"one"},
+		"ok":           {"one"},
+		"access_token": {"one"},
 	}
 
 	clean := filterParams(std.FilterFields, values)
@@ -152,8 +152,8 @@ func TestFilterParams(t *testing.T) {
 
 func TestFlattenValues(t *testing.T) {
 	values := map[string][]string{
-		"a": []string{"one"},
-		"b": []string{"one", "two"},
+		"a": {"one"},
+		"b": {"one", "two"},
 	}
 
 	flattened := flattenValues(values)


### PR DESCRIPTION
When the Rollbar Client has problems reporting to the Rollbar API, it uses the standard `log` package to log those problems. Sometimes it is important to use a different logger for this.

The logger can be optionally added, keeping the same default as before, so this change is backwards compatible.