### PR TITLE
Fix a fatal error caused by a race condition

### DIFF
--- a/client.go
+++ b/client.go
@@ -283,34 +283,38 @@ func (c *AsyncClient) Close() error {
 func (c *AsyncClient) buildBody(level, title string, extras map[string]interface{}) map[string]interface{} {
 	timestamp := time.Now().Unix()
 
-	custom := c.Custom
-	for k, v := range extras {
-		custom[k] = v
-	}
-
-	data := map[string]interface{}{
-		"environment":  c.Environment,
-		"title":        title,
-		"level":        level,
-		"timestamp":    timestamp,
-		"platform":     runtime.GOOS,
-		"language":     "go",
-		"code_version": c.CodeVersion,
-		"server": map[string]interface{}{
-			"host": c.ServerHost,
-			"root": c.ServerRoot,
-		},
-		"notifier": map[string]interface{}{
-			"name":    NAME,
-			"version": VERSION,
-		},
-		"custom": custom,
-	}
-
 	return map[string]interface{}{
 		"access_token": c.Token,
-		"data":         data,
+		"data": map[string]interface{}{
+			"environment":  c.Environment,
+			"title":        title,
+			"level":        level,
+			"timestamp":    timestamp,
+			"platform":     runtime.GOOS,
+			"language":     "go",
+			"code_version": c.CodeVersion,
+			"server": map[string]interface{}{
+				"host": c.ServerHost,
+				"root": c.ServerRoot,
+			},
+			"notifier": map[string]interface{}{
+				"name":    NAME,
+				"version": VERSION,
+			},
+			"custom": buildCustom(c.Custom, extras),
+		},
 	}
+}
+
+func buildCustom(custom map[string]interface{}, extras map[string]interface{}) map[string]interface{} {
+	m := map[string]interface{}{}
+	for k, v := range custom {
+		m[k] = v
+	}
+	for k, v := range extras {
+		m[k] = v
+	}
+	return m
 }
 
 // Extract error details from a Request to a format that Rollbar accepts.

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -108,6 +108,10 @@ func TestBuildBody(t *testing.T) {
 	if custom["OVERRIDDEN_CUSTOM_KEY"] != "EXTRA" {
 		t.Error("extra custom should overwrite base custom where keys match")
 	}
+
+	if GetCustom()["EXTRA_CUSTOM_KEY"] != nil {
+		t.Error("adding extra modified the client custom data config")
+	}
 }
 
 func TestErrorRequest(t *testing.T) {


### PR DESCRIPTION
The client custom data was mistakenly modified every time an error is sent with extras.

Doing `custom := c.Custom` does not copy the map, because maps are pointers in Go, it just makes a new pointer (see playground example: https://play.golang.org/p/9JELtutwxT).

This change adds a test to check for proper custom data and fixes the issue by making a new map.